### PR TITLE
Fixing the linear regression

### DIFF
--- a/src/linear_regression.jl
+++ b/src/linear_regression.jl
@@ -1,5 +1,5 @@
 function linear_regression(X, y)
     𝐗 = mapreduce(x->[1;x]', vcat, X)
     θ = 𝐗\y
-    return x -> [1;x]'θ
+    return x -> [ones(size(x,1)) x]*θ
 end

--- a/src/linear_regression_one_liner.jl
+++ b/src/linear_regression_one_liner.jl
@@ -1,1 +1,1 @@
-linear_regression(X, y, 𝐗=[ones(size(y)) X], θ=𝐗\y) = x -> [1;x]'θ
+linear_regression(X, y, 𝐗=[ones(size(y)) X], θ=𝐗\y) = x -> [ones(size(x,1)) x]*θ

--- a/src/linear_regression_one_liner.jl
+++ b/src/linear_regression_one_liner.jl
@@ -1,1 +1,1 @@
-linear_regression(X, y, 𝐗=mapreduce(x->[1;x]', vcat, X), θ=𝐗\y) = x -> [1;x]'θ
+linear_regression(X, y, 𝐗=[ones(size(y)) X], θ=𝐗\y) = x -> [1;x]'θ


### PR DESCRIPTION
The mapreduce implementation does not work when X has multiple columns:
![image](https://user-images.githubusercontent.com/47037088/155176515-25814b91-b126-444f-b989-43c6bf2e89f3.png)
That's because it will produce, in this 10 x 2 case, a 20 rows-matrix. 
![image](https://user-images.githubusercontent.com/47037088/155176736-5310fe1c-1cad-465b-bf0e-82c71d42577a.png)

mapreduce was also a convoluted way to hcat a vector of ones anyways. So here's why I proposed this quick fix that I think is more elegant:
![image](https://user-images.githubusercontent.com/47037088/155179028-54e93e14-4de5-47ea-a2f9-7e6982d43bed.png)


